### PR TITLE
Change shebang to /usr/bin/env python

### DIFF
--- a/s3redirect.py
+++ b/s3redirect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Provides a command line tool to synchronize web site redirects with an
 Amazon S3 bucket.


### PR DESCRIPTION
This makes it possible to run the s3redirects.py file directly inside a python
virtualenv.
